### PR TITLE
correct readme for md.eco example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you have this in your `docpad.cson`
 		lastname: 'Lupton'
 		fullname: '<t>firstname</t> <t>lastname</t>'
 		markdownExample: '<t render="markdown">this is so **awesome**</t>'
-		markdownEcoExample: '<t render="md.eco">here is a random number: **<%- Math.random() %>**</t>'
+		markdownEcoExample: '<t render="html.md.eco">here is a random number: **<%- Math.random() %>**</t>'
 }
 ```
 


### PR DESCRIPTION
To use marked markdown with eco, text plugin example needs html.md.eco

As the example is listed, the `md.eco` example will not render the
markdown, but instead `**0.7382947329847923**`

However if you simply add `html` prefix then it will process it properly. `html.md.eco`

This updates readme to match what the tests have.
